### PR TITLE
Check if a file exists before copying

### DIFF
--- a/ph.sh
+++ b/ph.sh
@@ -15,7 +15,7 @@ while getopts ":i:" opt; do
             for LINE in $(find $OPTARG -name '*.CR2') ; do
                 HASH=$(cut -d ' ' -f1 <(sha1sum ${LINE}))
                 NEWFILE=${LIBRARY}/raw/${HASH}.CR2
-                cp ${LINE} ${NEWFILE}
+                [ -f ${NEWFILE} ] || cp ${LINE} ${NEWFILE}
                 dcraw -c -e ${NEWFILE} > ${LIBRARY}/thumbnail/${HASH}.JPG
             done
             ;;


### PR DESCRIPTION
Fixes #2

Does not check to make sure the files are actually the same thing.
