### PR TITLE
Make dark theme optional

### DIFF
--- a/photoshell/__main__.py
+++ b/photoshell/__main__.py
@@ -11,7 +11,8 @@ config_path = os.path.join(os.environ['HOME'], '.photoshell.yaml')
 
 config = dict(
     {
-        'library': os.path.join(os.environ['HOME'], 'Pictures/Photoshell')
+        'library': os.path.join(os.environ['HOME'], 'Pictures/Photoshell'),
+        'dark_theme': True
     }
 )
 if os.path.isfile(config_path):
@@ -23,4 +24,4 @@ else:
 
 # Open photo viewer
 library = Library(config['library'])
-Window(library, Slideshow())
+Window(config, library, Slideshow())

--- a/photoshell/views/window.py
+++ b/photoshell/views/window.py
@@ -8,7 +8,7 @@ from photoshell.views.slideshow import Slideshow
 
 class Window(Gtk.Window):
 
-    def __init__(self, library, primary_view):
+    def __init__(self, config, library, primary_view):
         super(Window, self).__init__()
 
         self.library = library
@@ -17,7 +17,8 @@ class Window(Gtk.Window):
 
         # Use Dark Theme
         settings = Gtk.Settings.get_default()
-        settings.set_property('gtk-application-prefer-dark-theme', True)
+        if 'dark_theme' in config and config['dark_theme'] == True:
+            settings.set_property('gtk-application-prefer-dark-theme', True)
 
         # Create Header
         self.header_bar = Gtk.HeaderBar()


### PR DESCRIPTION
Not sure if this is even something we want to support. Dark themes are better for reducing distractions (when you want to focus on your photo). Just did it; don't really have an argument for or against. Maybe someone with visibility issues couldn't see the dark theme well?

Thoughts?
