### PR TITLE
Add pure python CR2 parser

### DIFF
--- a/photoshell/raw/cr2.py
+++ b/photoshell/raw/cr2.py
@@ -103,7 +103,8 @@ class Cr2(object):
                     (self.value,) = struct.unpack_from(
                         self.parent.endian_flag + tag_fmt, buf)
                     if tag_fmt[-1] == 's':
-                        self.value = self.value.decode("utf-8")
+                        # Decode to UTF-8, removing null terminator.
+                        self.value = self.value.decode("utf-8")[:-1]
                 return self.value
 
         def __init__(self, offset, parent):


### PR DESCRIPTION
Wouldn't mind a code review on tihs one before I squash / merge. I'm sure most of this is not very pythonic, but it works.

Simple usage example which fetches the date the photo was taken and lots of other info in [this gist](https://gist.github.com/SamWhited/eea9be1972abad0d1c9f).

Parser is currently read only. No idea why we'd want to write CR2 files, so I didn't bother (though it would be quite easy to add write support).

We could also just wrap libraw or something, but I wanted to understand the CR2 format anyways, so this was a good way to learn me some knowledge.
