### PR TITLE
Add basic photo export support

### DIFF
--- a/photoshell/views/photo_exporter.py
+++ b/photoshell/views/photo_exporter.py
@@ -1,0 +1,49 @@
+import os
+
+from gi.repository import Gtk
+from wand.image import Image
+
+
+class PhotoExporter(Gtk.FileChooserDialog):
+
+    def __init__(self, window):
+        super(PhotoExporter, self).__init__(
+            'Export photo',
+            window,
+            Gtk.FileChooserAction.SAVE,
+            (
+                Gtk.STOCK_CANCEL,
+                Gtk.ResponseType.CANCEL,
+                'Save',
+                Gtk.ResponseType.OK,
+            ),
+        )
+
+        self._window = window
+
+    def export_photo(self, photo):
+        # TODO: photo is actually an photoshell.image.Image
+
+        response = self.run()
+
+        if response == Gtk.ResponseType.OK:
+            filename = self.get_filename()
+        else:
+            filename = None
+
+        def write_image(photo, format, filename):
+            with Image(filename=photo.image_path) as image:
+                image.format = format
+                image.save(filename=filename)
+
+        if filename and response == Gtk.ResponseType.OK:
+            extension = os.path.splitext(filename)[-1]
+            if extension in ['.PNG', '.png']:
+                write_image(photo, 'png', filename)
+            elif extension in ['.jpg', '.JPG', '.jpeg', '.JPEG']:
+                write_image(photo, 'jpeg', filename)
+            else:
+                # TODO: show error here
+                pass
+
+        self.destroy()

--- a/photoshell/views/photo_import.py
+++ b/photoshell/views/photo_import.py
@@ -105,6 +105,7 @@ class PhotoImporter(Gtk.FileChooserDialog):
         if filename and response == Gtk.ResponseType.OK:
             def do_import():
                 GLib.idle_add(self._window.import_button.set_sensitive, False)
+                GLib.idle_add(self._window.export_button.set_sensitive, False)
                 GLib.idle_add(self._window.progress.set_fraction, 0)
                 GLib.idle_add(
                     self._window.header_bar.pack_start, self._window.progress)
@@ -123,6 +124,7 @@ class PhotoImporter(Gtk.FileChooserDialog):
                     delete_originals=self.options['delete_originals'])
 
                 GLib.idle_add(self._window.import_button.set_sensitive, True)
+                GLib.idle_add(self._window.export_button.set_sensitive, True)
                 GLib.idle_add(
                     self._window.header_bar.remove, self._window.progress)
                 GLib.idle_add(

--- a/photoshell/views/window.py
+++ b/photoshell/views/window.py
@@ -4,6 +4,7 @@ from gi.repository import Gdk
 from gi.repository import GdkPixbuf
 
 from photoshell.views.grid import Grid
+from photoshell.views.photo_exporter import PhotoExporter
 from photoshell.views.photo_import import PhotoImporter
 from photoshell.views.slideshow import Slideshow
 
@@ -38,7 +39,7 @@ class Window(Gtk.Window):
 
         # Use Dark Theme
         settings = Gtk.Settings.get_default()
-        if 'dark_theme' in config and config['dark_theme'] == True:
+        if 'dark_theme' in config and config['dark_theme'] is True:
             settings.set_property('gtk-application-prefer-dark-theme', True)
 
         # Create Header
@@ -77,6 +78,16 @@ class Window(Gtk.Window):
 
         self.header_bar.pack_start(self.import_button)
 
+        # Create import button
+        self.export_button = Gtk.Button()
+        export_icon = Gio.ThemedIcon(name="document-save-symbolic")
+        export_image = Gtk.Image.new_from_gicon(
+            export_icon, Gtk.IconSize.BUTTON)
+        self.export_button.connect('clicked', self.export_photo)
+        self.export_button.add(export_image)
+
+        self.header_bar.pack_start(self.export_button)
+
         self.progress = Gtk.ProgressBar()
         self.progress.set_text('Importing...')
         self.progress.set_show_text(True)
@@ -87,7 +98,8 @@ class Window(Gtk.Window):
         settings_image = Gtk.Image.new_from_gicon(
             settings_icon, Gtk.IconSize.BUTTON)
         settings_button.add(settings_image)
-        self.header_bar.pack_end(settings_button)
+        # TODO: add this back when it works
+        # self.header_bar.pack_end(settings_button)
 
         # Create terminal button
         terminal_button = Gtk.Button()
@@ -95,7 +107,8 @@ class Window(Gtk.Window):
         terminal_image = Gtk.Image.new_from_gicon(
             terminal_icon, Gtk.IconSize.BUTTON)
         terminal_button.add(terminal_image)
-        self.header_bar.pack_end(terminal_button)
+        # TODO: add this back when it works
+        # self.header_bar.pack_end(terminal_button)
 
         # Create view box
         view_box = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL)
@@ -187,6 +200,9 @@ class Window(Gtk.Window):
 
     def import_folder(self, button):
         PhotoImporter(self).import_photos()
+
+    def export_photo(self, button):
+        PhotoExporter(self).export_photo(self.selection.current())
 
     def on_key_release(self, widget, ev, data=None):
         self.keyReleaseBindings.get(ev.keyval, lambda s, w: None)(self, widget)


### PR DESCRIPTION
Added basic photo export support. From `slideshow` view, click the export button and chose a name ending in `png` or `jpg` and the file will be exported in that format. PNG is a little slow to export, but it works.