### PR TITLE
Remove dcraw dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,6 @@ A GTK3 application for managing photos.
 ## Usage
 
 Before running `photoshell`, you will need to have a working Python 3.4
-environment (including pip and virtualenv), and the dcraw utility installed. To
-run `photoshell`, just do `make run` from the project directory. The first time
-you launch `photoshell` it may take a few minutes to install dependencies.
+environment (including pip and virtualenv). To run `photoshell`, just do `make
+run` from the project directory. The first time you launch `photoshell` it may
+take a few minutes to install dependencies.

--- a/photoshell/photo.py
+++ b/photoshell/photo.py
@@ -2,7 +2,6 @@ from collections import namedtuple
 from datetime import datetime
 import os
 import shutil
-import subprocess
 
 import wand.image
 import yaml
@@ -114,9 +113,7 @@ class Photo(_Photo):
             )
 
         if not os.path.isfile(developed_path):
-            # TODO: fail gracefully here (or even at startup)
-            blob = subprocess.check_output(
-                ['dcraw', '-c', '-e', self.raw_path])
+            blob = Raw(filename=self.raw_path).fhandle.get_quarter_size_rgb()
 
             with wand.image.Image(blob=blob) as image:
                 with image.convert('jpeg') as developed:


### PR DESCRIPTION
Extract the quarter size RGB JPEG from the CR2 files using `rawphoto` instead of dcraw.

Fixes #55 (no longer applicable)
Fixes #37