### PR TITLE
Test against pypy3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 env:
   - TOXENV=py33
   - TOXENV=py34
+  - TOXENV=pypy3
 install:
   - "pip install ."
   - "pip install -r requirements.txt"

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 project = photoshell
-envlist = py33,py34
+envlist = py33,py34,pypy3
 
 [testenv]
 deps =


### PR DESCRIPTION
Because why not? (makes tests take longer, but support for all modern Python versions seems like a good idea since we want this easily installed on as many systems as possible)