### PR TITLE
Stop saving jpegs as tiffs

### DIFF
--- a/photoshell/photo.py
+++ b/photoshell/photo.py
@@ -65,7 +65,8 @@ class Photo(_Photo):
 
         # Don't trust the metadata; always use our own path and hash.
         metadata['raw_path'] = photo_path
-        metadata['file_hash'] = file_hash
+        if file_hash:
+            metadata['file_hash'] = file_hash
 
         # TODO: rawphoto doesn't return the data in the same format as the
         # sidecar

--- a/photoshell/photo.py
+++ b/photoshell/photo.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import os
 import shutil
 
-import wand.image
 import yaml
 
 from photoshell.util import dict_to_tuple
@@ -103,21 +102,20 @@ class Photo(_Photo):
         else:
             developed_name = '{file_hash}.{extension}'.format(
                 file_hash=self.file_hash,
-                extension='tiff',
+                extension='jpg',
             )
 
             developed_path = os.path.join(
                 cache_path,
-                'tiff',
+                'jpg',
                 developed_name,
             )
 
         if not os.path.isfile(developed_path):
             blob = Raw(filename=self.raw_path).fhandle.get_quarter_size_rgb()
 
-            with wand.image.Image(blob=blob) as image:
-                with image.convert('jpeg') as developed:
-                    developed.save(filename=developed_path)
+            with open(developed_path, 'wb') as f:
+                f.write(blob)
 
         photo_dict = tuple_to_dict(self)
         photo_dict['developed_path'] = developed_path

--- a/photoshell/util.py
+++ b/photoshell/util.py
@@ -36,4 +36,7 @@ class Progress(object):
 
     def advance(self):
         self.num_complete += 1
+        return self.percent()
+
+    def percent(self):
         return self.num_complete / self.num_to_complete

--- a/tests/library_test.py
+++ b/tests/library_test.py
@@ -65,7 +65,7 @@ def test_discover(config, source_dir):
     library = Library(config)
 
     with mock.patch.object(Photo, 'load', create_photo):
-        photo_count, photo_iterator = library.discover(source_dir.strpath)
+        progress, photo_iterator = library.discover(source_dir.strpath)
         photo_list = [photo for photo in photo_iterator()]
 
         # Make sure all the RAW files are accounted for.
@@ -77,6 +77,6 @@ def test_discover(config, source_dir):
         library.add(photo_list[0])
 
         # And make sure the added file isn't discovered a second time.
-        photo_count, photo_iterator = library.discover(source_dir.strpath)
-        assert photo_count == 2
+        progress, photo_iterator = library.discover(source_dir.strpath)
+        assert len([p for p in photo_iterator()]) == 2
         assert [photo for photo in photo_iterator()] == photo_list[1:]


### PR DESCRIPTION
Use JPEG previews for developed images. Also fixed bug where duplicates weren't recognized because the hash from the library wasn't being trusted.