### PR TITLE
Start work on a photo widget

### DIFF
--- a/photoshell/views/slideshow.py
+++ b/photoshell/views/slideshow.py
@@ -1,15 +1,16 @@
 from threading import Lock
 
 from gi.repository import Gtk
+from photoshell.widgets.photodisplay import PhotoDisplay
 
 
 class Slideshow(Gtk.Box):
 
     def __init__(self):
         super(Slideshow, self).__init__()
-        self.image = Gtk.Image()
+        self.canvas = PhotoDisplay()
         self.image_path = None
-        self.pack_start(self.image, True, True, 0)
+        self.pack_start(self.canvas, True, True, 0)
         self.mutex = Lock()
 
     def render_selection(self, selection):
@@ -18,11 +19,6 @@ class Slideshow(Gtk.Box):
         new_photo = selection.current_photo()
 
         if new_photo:
-            # TODO: image path is bad criteria for redrawing if we re-develop
-            if self.image_path != new_photo.raw_path:
-                self.image.set_from_pixbuf(
-                    new_photo.gtk_pixbuf(selection.library_path),
-                )
-                self.image_path = new_photo.raw_path
+            self.canvas.set_photo(new_photo)
 
         self.mutex.release()

--- a/photoshell/widgets/photodisplay.py
+++ b/photoshell/widgets/photodisplay.py
@@ -1,0 +1,49 @@
+from gi.repository import Gdk
+from gi.repository import Gtk
+
+# from photoshell.photo import Photo
+
+
+class PhotoDisplay(Gtk.DrawingArea):
+
+    def __init__(self, photo=None):
+        super(PhotoDisplay, self).__init__()
+
+        self.photo = photo
+
+        self.set_size_request(30, 100)
+
+        self.x_offset = 0
+        self.y_offset = 0
+
+        self.drag = Gtk.GestureDrag.new(self)
+        self.drag.connect('drag-end', self.on_drag_end)
+        self.drag.connect('drag-update', self.on_drag)
+
+        # Setup the draw event
+        self.connect('draw', self.draw)
+
+        self.show()
+
+    def set_photo(self, photo):
+        self.photo = photo
+        # Gdk.Window.invalidate_rect(self.get_allocation(), False)
+        self.queue_draw()
+
+    def draw(self, widget, cr):
+        if self.photo is not None:
+            pb = self.photo.gtk_pixbuf(
+                self.photo.developed_path,
+                max_width=self.get_allocated_width(),
+                max_height=self.get_allocated_height()
+            )
+            Gdk.cairo_set_source_pixbuf(cr, pb, self.x_offset, self.y_offset)
+            cr.paint()
+
+    def on_drag_end(self, event, x_offset, y_offset):
+        self.x_offset = 0
+        self.queue_draw()
+
+    def on_drag(self, event, x_offset, y_offset):
+        self.x_offset = x_offset
+        self.queue_draw()


### PR DESCRIPTION
Start work on displaying the photos using a custom photo widget (instead of a `Gtk.Image`). This will allow us to animate or transform the image (eg. to dim parts of the image when cropping, to show the cropped image while still maintaining the full image in the pixbuf, etc.)

This also adds a simple drag animation when dragging with the touch screen (it's not very smooth, and needs some work).

I'm not sure if this is the way we want to do this, and the drag animation should only bein the slideshow view (so it should probably be handled at the window level), but I went ahead and made a pull requst to get feedback (this may not even be something we want to do).