### PR TITLE
Allow "launching" with no UI

### DIFF
--- a/photoshell/__main__.py
+++ b/photoshell/__main__.py
@@ -1,22 +1,45 @@
 import os
 import signal
 
+from enum import Enum
+
 from photoshell.config import Config
 from photoshell.library import Library
 from photoshell.views.slideshow import Slideshow
 from photoshell.views.window import Window
 
-c = Config({
-    'library': os.path.join(os.environ['HOME'], 'Pictures/Photoshell'),
-    'dark_theme': True,
-    'import_path': '%Y-%m-%d/{original_filename}'
-})
 
-# Open photo viewer
-library = Library(c)
+class UI(Enum):
+    cli = 0
+    gui = 1
 
-signal.signal(signal.SIGINT, signal.SIG_DFL)
-Window(c, library, Slideshow())
 
-if c.exists():
-    c.flush()
+def setup(ui=UI.cli):
+    """
+    Setup the main photoshell app.
+
+    Parameters:
+      ui (UI enum) — Use the GUI or the CLI
+    """
+    c = Config({
+        'library': os.path.join(os.environ['HOME'], 'Pictures/Photoshell'),
+        'dark_theme': True,
+        'import_path': '%Y-%m-%d/{original_filename}'
+    })
+
+    # Open photo viewer
+    library = Library(c)
+    window = None
+    if ui == UI.gui:
+        signal.signal(signal.SIGINT, signal.SIG_DFL)
+        window = Window(c, library, Slideshow())
+
+        if c.exists():
+            c.flush()
+
+    return (c, library, window)
+
+if __name__ == "__main__":
+    from gi.repository import Gtk
+    setup(ui=UI.gui)
+    Gtk.main()

--- a/photoshell/views/window.py
+++ b/photoshell/views/window.py
@@ -158,9 +158,6 @@ class Window(Gtk.Window):
 
         self.update_ui()
 
-        # Start the GTK loop
-        Gtk.main()
-
     def render_selection(self, selection):
         self.selection = selection
         self.update_ui()


### PR DESCRIPTION
Allows "launching" photoshell with no UI.

This lets you either just get a handle on the library and config file, or on the main Window before it's actually been shown.

Launching normally works fine still:

```bash
python -m photoshell # GUI is shown
```

Launching from a REPL is a bit more involved:

```python
# Old way:
from photoshell import __main__ # UI launches

# New way:
from photoshell.__main__ import UI, setup
config, library, window = setup(UI.gui)
Gtk.main() # UI Launches, and we have a handle on Window (not that it matters here because the Gtk main loop is in the same thread)
```

Or we can just ignore the Window and Gtk is no longer required:

```python
config, library, _ = setup(UI.cli) # Gives us a handle on the config and library so we can import other photoshell stuff and perform actions on them with no UI
```

I'm not sure if this is actually useful or not... if you're an "advanced" user who wants to use this, you could probably just construct the config and the library by yourself, but it seems like a good first step towards making photoshell also work as a CLI.